### PR TITLE
fix: add --no-sandbox flag for Chrome in CI environments

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -40,6 +40,12 @@ func (session *Session) NewChromeOpt(options NewChromeOptions) (chromeSession *C
 			chromedp.DisableGPU,
 		)
 	}
+	
+	// Add --no-sandbox flag for CI environments to avoid sandbox restrictions
+	// This is needed for Ubuntu 23.10+ with AppArmor restrictions in CI
+	if os.Getenv("CI") == "true" {
+		allocOptions = append(allocOptions, chromedp.NoSandbox)
+	}
 
 	downloadPath, err := filepath.Abs(path.Join(session.getDirectory(), "chrome"))
 	if err != nil {


### PR DESCRIPTION
Fixes Chrome test failures in GitHub Actions CI due to sandbox restrictions on Ubuntu 23.10+ with AppArmor.

## Changes
- Added CI environment detection using `CI` environment variable
- Automatically adds `chromedp.NoSandbox` option when running in CI
- Only affects CI environments, preserving local development behavior

## Testing
This fix addresses the specific Chrome startup error seen in GitHub Actions while maintaining existing behavior for local development.

Fixes #63

Generated with [Claude Code](https://claude.ai/code)