### PR TITLE
feat: add debug step labeling for enhanced logging visibility

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -106,7 +106,7 @@ func (session *ChromeSession) SaveHtml(filename *string) chromedp.Action {
 		if filename != nil {
 			*filename = fn
 		}
-		session.Printf("**** SAVE to %v (%v bytes)\n", fn, len(body))
+		session.Printf("%s SAVE to %v (%v bytes)\n", session.getDebugPrefix(), fn, len(body))
 		var title string
 		err = chromedp.Title(&title).Do(ctxt)
 		if err == nil {
@@ -195,7 +195,7 @@ func (session *ChromeSession) DownloadFile(filename *string, options DownloadFil
 				if !info.ModTime().Before(startTime) {
 					if match, _ := filepath.Match(options.Glob, file.Name()); match {
 						*filename = path.Join(session.DownloadPath, file.Name())
-						session.Printf("**** DOWNLOADED: %v\n", *filename)
+						session.Printf("%s DOWNLOADED: %v\n", session.getDebugPrefix(), *filename)
 						return nil
 					} else {
 						if info.ModTime().After(latestTime) {
@@ -220,7 +220,7 @@ func (session *ChromeSession) DownloadFile(filename *string, options DownloadFil
 			}
 
 			*filename = downloaded
-			session.Printf("**** DOWNLOADED: %v\n", *filename)
+			session.Printf("%s DOWNLOADED: %v\n", session.getDebugPrefix(), *filename)
 			return nil
 		}
 	}
@@ -250,7 +250,7 @@ func (session *ChromeSession) SaveFile(filename *string) chromedp.ActionFunc {
 		if err != nil {
 			return err
 		}
-		session.Printf("**** SAVE %v to %v (%v bytes)\n", *filename, fn, len(body))
+		session.Printf("%s SAVE %v to %v (%v bytes)\n", session.getDebugPrefix(), *filename, fn, len(body))
 		return nil
 	}
 }

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,163 @@
+package scraper
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestSession_DebugStep(t *testing.T) {
+	t.Run("SetDebugStep and ClearDebugStep", func(t *testing.T) {
+		logger := &BufferedLogger{}
+		session := NewSession("test_session", logger)
+
+		// Test initial state (no debug step)
+		if session.debugStep != "" {
+			t.Errorf("Expected initial debugStep to be empty, got %q", session.debugStep)
+		}
+
+		// Test SetDebugStep
+		testStep := "テストステップ"
+		session.SetDebugStep(testStep)
+		if session.debugStep != testStep {
+			t.Errorf("Expected debugStep to be %q, got %q", testStep, session.debugStep)
+		}
+
+		// Test ClearDebugStep
+		session.ClearDebugStep()
+		if session.debugStep != "" {
+			t.Errorf("Expected debugStep to be empty after clear, got %q", session.debugStep)
+		}
+	})
+
+	t.Run("getDebugPrefix", func(t *testing.T) {
+		logger := &BufferedLogger{}
+		session := NewSession("test_session", logger)
+
+		// Test without debug step
+		prefix := session.getDebugPrefix()
+		expected := "****"
+		if prefix != expected {
+			t.Errorf("Expected prefix %q, got %q", expected, prefix)
+		}
+
+		// Test with debug step
+		testStep := "ログイン処理"
+		session.SetDebugStep(testStep)
+		prefix = session.getDebugPrefix()
+		expected = fmt.Sprintf("**** [%s]", testStep)
+		if prefix != expected {
+			t.Errorf("Expected prefix %q, got %q", expected, prefix)
+		}
+	})
+
+	t.Run("debug step in SAVE log", func(t *testing.T) {
+		// Create a test server
+		testContent := "<html><body>Test content</body></html>"
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, testContent)
+		}))
+		defer ts.Close()
+
+		// Create temp directory
+		dir, err := os.MkdirTemp(".", "session_test*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(dir)
+
+		sessionName := "debug_test_session"
+		err = os.Mkdir(path.Join(dir, sessionName), 0744)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		logger := &BufferedLogger{}
+		session := NewSession(sessionName, logger)
+		session.FilePrefix = dir + "/"
+		session.SaveToFile = true
+
+		// Test without debug step
+		_, err = session.Get(ts.URL)
+		if err != nil {
+			t.Fatalf("Get() error: %v", err)
+		}
+
+		logOutput := logger.buffer.String()
+		if !strings.Contains(logOutput, "**** SAVE to") {
+			t.Errorf("Expected default SAVE log format, got: %s", logOutput)
+		}
+
+		// Clear logger buffer
+		logger.buffer.Reset()
+
+		// Test with debug step
+		debugStep := "データ取得"
+		session.SetDebugStep(debugStep)
+		_, err = session.Get(ts.URL)
+		if err != nil {
+			t.Fatalf("Get() error: %v", err)
+		}
+
+		logOutput = logger.buffer.String()
+		expectedLog := fmt.Sprintf("**** [%s] SAVE to", debugStep)
+		if !strings.Contains(logOutput, expectedLog) {
+			t.Errorf("Expected debug step in SAVE log %q, got: %s", expectedLog, logOutput)
+		}
+	})
+
+	t.Run("debug step in LOAD log", func(t *testing.T) {
+		// Create temp directory and test file
+		dir, err := os.MkdirTemp(".", "session_test*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(dir)
+
+		sessionName := "debug_load_test_session"
+		sessionDir := path.Join(dir, sessionName)
+		err = os.Mkdir(sessionDir, 0744)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a test HTML file
+		testContent := "<html><body>Test content</body></html>"
+		testFile := path.Join(sessionDir, "1.html")
+		err = os.WriteFile(testFile, []byte(testContent), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create content type file
+		contentTypeFile := testFile + ".ContentType"
+		err = os.WriteFile(contentTypeFile, []byte("text/html"), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		logger := &BufferedLogger{}
+		session := NewSession(sessionName, logger)
+		session.FilePrefix = dir + "/"
+		session.NotUseNetwork = true // Force loading from file
+
+		// Test with debug step
+		debugStep := "ファイル読み込み"
+		session.SetDebugStep(debugStep)
+
+		_, err = session.Get("http://example.com")
+		if err != nil {
+			t.Fatalf("Get() error: %v", err)
+		}
+
+		logOutput := logger.buffer.String()
+		expectedLog := fmt.Sprintf("**** [%s] LOAD from", debugStep)
+		if !strings.Contains(logOutput, expectedLog) {
+			t.Errorf("Expected debug step in LOAD log %q, got: %s", expectedLog, logOutput)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add debug step tracking functionality to Session and ChromeSession for better debugging visibility
- Update all logging statements to include debug step labels in format "**** [step]"
- Add comprehensive test coverage for both Session and ChromeSession debug functionality

## Changes Made
### Core Implementation
- **Session struct**: Added `debugStep` field to track current operation step
- **New API methods**: 
  - `SetDebugStep(step string)` - Set debug step label
  - `ClearDebugStep()` - Clear debug step label
  - `getDebugPrefix()` - Generate formatted prefix for logs

### Updated Logging
- **session.go**: Updated SAVE and LOAD log messages to include debug step
- **chrome.go**: Updated SAVE, DOWNLOADED, and SaveFile log messages to include debug step
- **Format**: Logs now show `**** [step_name] SAVE to...` instead of `**** SAVE to...`

### Test Coverage
- **session_test.go**: New comprehensive test file covering:
  - API functionality (SetDebugStep/ClearDebugStep)
  - Prefix generation logic
  - Integration with SAVE and LOAD operations
- **chrome_test.go**: Additional tests covering:
  - Chrome-specific logging with debug steps
  - Inheritance behavior from embedded Session

## Usage Example
```go
session.SetDebugStep("ログインページ取得")
page, err := session.GetPage("https://example.com/login")
// Log: **** [ログインページ取得] SAVE to session/1.html (12345 bytes)

chromeSession.SetDebugStep("フォーム送信")
resp, err := chromeSession.RunNavigate("https://example.com/submit")
// Log: **** [フォーム送信] SAVE to session/2.html (23456 bytes)

session.ClearDebugStep()
```

## Test Results
✅ All tests pass (including new debug step tests)
✅ No regression in existing functionality
✅ Code formatting and linting clean

## Benefits
- **Enhanced Debugging**: Easily identify which step/operation generated each saved file
- **Better Development Experience**: Clear visibility into scraping workflow progress
- **Backward Compatible**: Default behavior unchanged when debug step not set
- **Inherited Functionality**: ChromeSession automatically gets debug step capabilities

🤖 Generated with [Claude Code](https://claude.ai/code)