### PR TITLE
feat: add automatic START/END logging to debug step methods

### DIFF
--- a/session.go
+++ b/session.go
@@ -105,10 +105,14 @@ func (session *Session) SaveCookie() error {
 // SetDebugStep sets the debug step label for logging
 func (session *Session) SetDebugStep(step string) {
 	session.debugStep = step
+	session.Printf("**** [%s] START\n", step)
 }
 
 // ClearDebugStep clears the debug step label
 func (session *Session) ClearDebugStep() {
+	if session.debugStep != "" {
+		session.Printf("**** [%s] END\n", session.debugStep)
+	}
 	session.debugStep = ""
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -160,4 +160,52 @@ func TestSession_DebugStep(t *testing.T) {
 			t.Errorf("Expected debug step in LOAD log %q, got: %s", expectedLog, logOutput)
 		}
 	})
+
+	t.Run("SetDebugStep logs START message", func(t *testing.T) {
+		logger := &BufferedLogger{}
+		session := NewSession("test_session", logger)
+
+		testStep := "テスト処理"
+		session.SetDebugStep(testStep)
+
+		logOutput := logger.buffer.String()
+		expectedLog := fmt.Sprintf("**** [%s] START\n", testStep)
+		if logOutput != expectedLog {
+			t.Errorf("Expected log %q, got %q", expectedLog, logOutput)
+		}
+	})
+
+	t.Run("ClearDebugStep logs END message", func(t *testing.T) {
+		logger := &BufferedLogger{}
+		session := NewSession("test_session", logger)
+
+		// Set debug step first
+		testStep := "テスト処理"
+		session.SetDebugStep(testStep)
+
+		// Clear buffer to test only ClearDebugStep output
+		logger.buffer.Reset()
+
+		// Clear debug step
+		session.ClearDebugStep()
+
+		logOutput := logger.buffer.String()
+		expectedLog := fmt.Sprintf("**** [%s] END\n", testStep)
+		if logOutput != expectedLog {
+			t.Errorf("Expected log %q, got %q", expectedLog, logOutput)
+		}
+	})
+
+	t.Run("ClearDebugStep does not log when no debug step is set", func(t *testing.T) {
+		logger := &BufferedLogger{}
+		session := NewSession("test_session", logger)
+
+		// Clear debug step without setting it first
+		session.ClearDebugStep()
+
+		logOutput := logger.buffer.String()
+		if logOutput != "" {
+			t.Errorf("Expected no log output, got %q", logOutput)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
Add automatic logging when setting and clearing debug steps to improve visibility into session debugging workflow.

- `SetDebugStep()` now automatically logs `**** [step] START` when called
- `ClearDebugStep()` now automatically logs `**** [step] END` when called (only if a step was previously set)
- Added comprehensive tests covering all logging scenarios

## Test plan
- [x] All existing tests pass
- [x] New tests verify START/END logging behavior
- [x] Edge case tested: ClearDebugStep without prior SetDebugStep
- [x] Code formatting and vet checks pass
- [x] Project builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)