### PR TITLE
feat: enhance ChromeUnmarshal with Unmarshaller interface and improved nth-child handling

### DIFF
--- a/chrome_unmarshal.go
+++ b/chrome_unmarshal.go
@@ -88,15 +88,15 @@ func hasFirstLastChildSelectors(cssSelector string) bool {
 func fillValue(ctx context.Context, cssSelector string, value reflect.Value, selected []string, opt UnmarshalOption) error {
 	// texts
 	if value.Kind() == reflect.Slice {
-		// nth-child関連のセレクタがある場合はエラーにする
+		// Error if nth-child related selectors are present
 		if hasUnsupportedNthSelectors(cssSelector) {
-			return fmt.Errorf("nth-child, nth-last-child, nth-last-of-type selectors are not supported for slice fields: %s", cssSelector)
+			return fmt.Errorf("unsupported selector '%s' for slice fields. nth-child, nth-last-child, nth-last-of-type selectors are not supported for slice fields", cssSelector)
 		}
 
 		rv := reflect.MakeSlice(value.Type(), len(selected), len(selected))
 		for i := 0; i < len(selected); i++ {
 			resolvedSelector := cssSelector
-			// first-child, last-child があったら nth-of-typeは付けない
+			// Skip nth-of-type addition if first-child or last-child selectors are present
 			if !hasFirstLastChildSelectors(cssSelector) {
 				resolvedSelector = resolveNthOfType(cssSelector, i)
 			}
@@ -150,7 +150,7 @@ func fillValue(ctx context.Context, cssSelector string, value reflect.Value, sel
 			return fmt.Errorf("failed CanAddr: %v, %v", value, value.Type())
 		}
 
-		// その型が Unmarshaller を実装しているならそれを呼ぶ
+		// Call custom Unmarshal method if the type implements Unmarshaller interface
 		if inf, ok := value.Addr().Interface().(Unmarshaller); ok {
 			return inf.Unmarshal(s)
 		}

--- a/chrome_unmarshal.go
+++ b/chrome_unmarshal.go
@@ -28,10 +28,11 @@ func parseNthOfTypeParam(cssSelector string) (string, int, int) {
 	if matched[4] != "" {
 		b, _ = strconv.Atoi(matched[4])
 	}
-	if matched[2] == "even" {
+	switch matched[2] {
+	case "even":
 		a = 2
 		b = 0
-	} else if matched[2] == "odd" {
+	case "odd":
 		a = 2
 		b = 1
 	}
@@ -57,13 +58,49 @@ func resolveNthOfType(cssSelector string, n int) string {
 	return fmt.Sprintf("%v:nth-of-type(%v)", strings.Join(selectors, " "), x)
 }
 
+func hasUnsupportedNthSelectors(cssSelector string) bool {
+	unsupportedPatterns := []string{
+		":nth-child(",
+		":nth-last-child(",
+		":nth-last-of-type(",
+	}
+	for _, pattern := range unsupportedPatterns {
+		if strings.Contains(cssSelector, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFirstLastChildSelectors(cssSelector string) bool {
+	firstLastPatterns := []string{
+		":first-child",
+		":last-child",
+	}
+	for _, pattern := range firstLastPatterns {
+		if strings.Contains(cssSelector, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
 func fillValue(ctx context.Context, cssSelector string, value reflect.Value, selected []string, opt UnmarshalOption) error {
 	// texts
 	if value.Kind() == reflect.Slice {
+		// nth-child関連のセレクタがある場合はエラーにする
+		if hasUnsupportedNthSelectors(cssSelector) {
+			return fmt.Errorf("nth-child, nth-last-child, nth-last-of-type selectors are not supported for slice fields: %s", cssSelector)
+		}
+
 		rv := reflect.MakeSlice(value.Type(), len(selected), len(selected))
 		for i := 0; i < len(selected); i++ {
-			// TODO nth-child, nth-last-child, nth-last-of-type があったらエラーにする / first-child, last-child があったら nth-of-typeは付けない
-			err := fillValue(ctx, resolveNthOfType(cssSelector, i), rv.Index(i), []string{selected[i]}, opt)
+			resolvedSelector := cssSelector
+			// first-child, last-child があったら nth-of-typeは付けない
+			if !hasFirstLastChildSelectors(cssSelector) {
+				resolvedSelector = resolveNthOfType(cssSelector, i)
+			}
+			err := fillValue(ctx, resolvedSelector, rv.Index(i), []string{selected[i]}, opt)
 			if err != nil {
 				return fmt.Errorf("#%d: %w", i, err)
 			}
@@ -111,6 +148,11 @@ func fillValue(ctx context.Context, cssSelector string, value reflect.Value, sel
 		}
 		if !value.CanAddr() {
 			return fmt.Errorf("failed CanAddr: %v, %v", value, value.Type())
+		}
+
+		// その型が Unmarshaller を実装しているならそれを呼ぶ
+		if inf, ok := value.Addr().Interface().(Unmarshaller); ok {
+			return inf.Unmarshal(s)
 		}
 
 		if value.Kind() == reflect.Struct {


### PR DESCRIPTION
## Summary

This PR enhances the ChromeUnmarshal implementation to achieve feature parity with the standard unmarshal.go implementation and improves CSS selector handling.

### Key Changes

- **Unmarshaller Interface Support**: Added support for custom Unmarshaller interface implementation in ChromeUnmarshal, bringing it to feature parity with unmarshal.go
- **Enhanced nth-child Handling**: Implemented proper error handling for unsupported nth-child variants (nth-child, nth-last-child, nth-last-of-type) in slice fields
- **Smart Selector Logic**: Added logic to skip automatic nth-of-type addition when first-child/last-child selectors are present
- **Code Quality**: Improved code with tagged switch statement as suggested by linter

### Test Coverage

- ✅ New test for Unmarshaller interface functionality
- ✅ Comprehensive error case tests for unsupported nth-child selectors  
- ✅ Validation tests for first-child/last-child selector behavior
- ✅ All existing tests pass without regression

### Technical Details

The implementation resolves inconsistencies between chrome_unmarshal.go and unmarshal.go by:

1. Adding Unmarshaller interface check in fillValue function (chrome_unmarshal.go:116-119)
2. Implementing hasUnsupportedNthSelectors() and hasFirstLastChildSelectors() helper functions
3. Adding proper error reporting for unsupported CSS selectors in slice contexts
4. Ensuring consistent behavior across both unmarshal implementations

🤖 Generated with [Claude Code](https://claude.ai/code)