### PR TITLE
feat: log download diagnostics on DownloadFile timeout

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -385,17 +386,28 @@ func (session *ChromeSession) DownloadFile(filename *string, options DownloadFil
 			// This captures the page state before clicking download button
 			session.captureCurrentHtml(ctxt)
 
+			// downloadMu guards suggestedFilename/downloadBegan: they are written
+			// from the ListenBrowser event goroutine and read from the timeout
+			// branch of the select loop below.
+			var downloadMu sync.Mutex
 			suggestedFilename := ""
+			downloadBegan := false
 			// Use ListenBrowser instead of ListenTarget to capture download events
 			// from popup windows opened via window.open()
 			chromedp.ListenBrowser(downloadCtx, func(ev interface{}) {
 				switch ev := ev.(type) {
 				case *browser.EventDownloadWillBegin:
+					downloadMu.Lock()
 					suggestedFilename = path.Join(session.DownloadPath, ev.SuggestedFilename)
+					downloadBegan = true
+					downloadMu.Unlock()
 				case *browser.EventDownloadProgress:
 					switch ev.State {
 					case browser.DownloadProgressStateCompleted:
-						download <- suggestedFilename
+						downloadMu.Lock()
+						name := suggestedFilename
+						downloadMu.Unlock()
+						download <- name
 					case browser.DownloadProgressStateCanceled:
 						download <- ""
 					}
@@ -448,6 +460,15 @@ func (session *ChromeSession) DownloadFile(filename *string, options DownloadFil
 					} else if matchErr != nil {
 						return matchErr
 					}
+					// Diagnostic: a bare DeadlineExceeded leaves a post-mortem unable
+					// to distinguish "click never triggered a download" from "download
+					// began but ran past the timeout". Record what was observed.
+					downloadMu.Lock()
+					began, suggested := downloadBegan, suggestedFilename
+					downloadMu.Unlock()
+					session.Printf("%s DOWNLOAD TIMEOUT after %v: downloadBegan=%v, suggestedFilename=%q, glob=%q",
+						session.getDebugPrefix(), time.Since(startTime).Round(time.Millisecond), began, suggested, options.Glob)
+					session.Printf("%s DOWNLOAD TIMEOUT: %s", session.getDebugPrefix(), describeDownloadDir(session.DownloadPath, startTime))
 					return downloadCtx.Err()
 
 				case <-ticker.C:
@@ -474,6 +495,36 @@ func (session *ChromeSession) DownloadFile(filename *string, options DownloadFil
 			}
 		}
 	}
+}
+
+// describeDownloadDir summarizes the download directory for timeout diagnostics.
+// It lists every entry, flagging ones modified at/after startTime ("new") and any
+// Chrome partial-download files ("partial"), so a post-mortem can tell whether a
+// download started at all.
+func describeDownloadDir(dir string, startTime time.Time) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Sprintf("download dir %v unreadable: %v", dir, err)
+	}
+	if len(entries) == 0 {
+		return fmt.Sprintf("download dir %v is empty (no file produced)", dir)
+	}
+	parts := make([]string, 0, len(entries))
+	for _, e := range entries {
+		desc := e.Name()
+		if info, ierr := e.Info(); ierr == nil {
+			tags := fmt.Sprintf("%dB", info.Size())
+			if !info.ModTime().Before(startTime) {
+				tags += ",new"
+			}
+			if strings.HasSuffix(e.Name(), ".crdownload") {
+				tags += ",partial"
+			}
+			desc += "(" + tags + ")"
+		}
+		parts = append(parts, desc)
+	}
+	return fmt.Sprintf("download dir %v contents: %s", dir, strings.Join(parts, ", "))
 }
 
 /**

--- a/chrome_download_test.go
+++ b/chrome_download_test.go
@@ -1,0 +1,63 @@
+package scraper
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDescribeDownloadDir(t *testing.T) {
+	t.Run("missing directory", func(t *testing.T) {
+		got := describeDownloadDir(filepath.Join(t.TempDir(), "does-not-exist"), time.Now())
+		if !strings.Contains(got, "unreadable") {
+			t.Errorf("missing dir: got %q, want it to mention 'unreadable'", got)
+		}
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		got := describeDownloadDir(t.TempDir(), time.Now())
+		if !strings.Contains(got, "is empty") {
+			t.Errorf("empty dir: got %q, want it to mention 'is empty'", got)
+		}
+	})
+
+	t.Run("flags new and partial entries", func(t *testing.T) {
+		dir := t.TempDir()
+		startTime := time.Now()
+
+		// write creates a file with the given content and modification time.
+		write := func(name, content string, modTime time.Time) {
+			p := filepath.Join(dir, name)
+			if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chtimes(p, modTime, modTime); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// A completed file from before the download started.
+		write("old.csv", "old", startTime.Add(-time.Hour))
+		// A file produced at/after the download start.
+		write("new.csv", "brand new", startTime.Add(time.Second))
+		// A Chrome partial-download file.
+		write("pending.csv.crdownload", "partial", startTime.Add(time.Second))
+
+		got := describeDownloadDir(dir, startTime)
+
+		// old.csv predates startTime: size only, no "new".
+		if !strings.Contains(got, "old.csv(3B)") {
+			t.Errorf("old.csv want 'old.csv(3B)' (no new flag): %q", got)
+		}
+		// new.csv is at/after startTime: flagged "new".
+		if !strings.Contains(got, "new.csv(9B,new)") {
+			t.Errorf("new.csv want 'new.csv(9B,new)': %q", got)
+		}
+		// .crdownload is both new and a partial download.
+		if !strings.Contains(got, "pending.csv.crdownload(7B,new,partial)") {
+			t.Errorf("crdownload want 'pending.csv.crdownload(7B,new,partial)': %q", got)
+		}
+	})
+}


### PR DESCRIPTION
## What

When `DownloadFile` times out without finding a matching file, it returned a bare `context.DeadlineExceeded`. A post-mortem then had no way to tell apart:

- the click never triggered a download (`downloadBegan=false`), vs
- a download began but ran past the timeout.

## Change

On the timeout path, log:

- `downloadBegan` / `suggestedFilename` — observed via the `ListenBrowser` download events. These cross goroutines (event callback vs. select loop), so they are now guarded by a mutex.
- the download directory contents via a new `describeDownloadDir` helper, flagging entries newer than the download start (`new`) and Chrome partial-download files (`partial` / `.crdownload`).

No behavior change to the success or error paths — only added logging on timeout.

## Context

This diagnostic immediately paid off in the dependent project: it revealed `downloadBegan=false`, pinpointing a click that no longer fires the page's handler rather than a too-short timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)